### PR TITLE
Listing of MPs in the party view

### DIFF
--- a/parliament/api.py
+++ b/parliament/api.py
@@ -271,6 +271,9 @@ class MemberResource(KamuResource):
 
     class Meta:
         queryset = Member.objects.select_related('party')
+        filtering = {
+            'party': ('exact',),
+        }
 
 class MemberActivityTypeResource(KamuResource):
     class Meta:

--- a/parliament/views.py
+++ b/parliament/views.py
@@ -395,7 +395,6 @@ def show_session(request, plsess):
 def get_embedded_resource_list(request, resource, options={}):
     old_GET = request.GET
     request.GET = options
-
     res = resource(api_name='v1')
     request_bundle = res.build_bundle(request=request)
     queryset = res.obj_get_list(request_bundle)
@@ -522,3 +521,13 @@ def show_party(request, name):
 
     return render_to_response("party/details.html", args,
         context_instance=RequestContext(request))
+
+def list_party_mps(request, name):
+    party = get_object_or_404(Party, name=name)
+
+    party_json = get_embedded_resource(request, PartyResource, party)
+    args = dict(party=party, party_json=party_json)
+    party_mp_list_json = get_embedded_resource_list(request, MemberResource, {'party': party})
+    args['member_list_json'] = party_mp_list_json
+
+    return render_to_response("party/mps.html", args, context_instance=RequestContext(request))

--- a/static/js/party-details.coffee
+++ b/static/js/party-details.coffee
@@ -1,0 +1,36 @@
+class @PartyView extends Backbone.View
+	#template: _.template $('#party-list-item-template').html()
+
+	render: ->
+		@$el.html @template @model.toJSON
+		return @
+
+# Horribly simplified version of the code in member-list
+
+class MemberListItemView extends Backbone.View
+    template: _.template $("#member-list-item-template").html()
+
+    render: ->
+        template_variables = @model.toJSON()
+        html = @template template_variables
+        return html
+
+class MemberListView extends Backbone.View
+    el: $("ul.member-list")
+
+    initialize: ->
+        @collection = new MemberList
+        @listenTo @collection, "reset", @render
+        @collection.reset party_list_json
+
+    render: ->
+        for member in @collection.models
+            item_view = new MemberListItemView
+                model: member
+            html = item_view.render()
+            @$el.append(html)
+
+$(->
+    member_list_view = new MemberListView
+    party_list = new PartyList party_json
+)

--- a/templates/party/details.html
+++ b/templates/party/details.html
@@ -31,19 +31,19 @@
                     <nav class="side-navigation">
                         <ul class="nav nav-pills nav-stacked">
                             <li class="active">
-                                <a href=#>Perustiedot</a>
+                                <a href="#">Perustiedot</a>
                             </li>
                             <li>
-                                <a href=#>Valiokuntapaikat</a>
+                                <a href="#">Valiokuntapaikat</a>
                             </li>
                             <li>
-                                <a href=#>Kansanedustajat</a>
+                                <a href="{% url 'parliament.views.list_party_mps' name=party.name %}">Kansanedustajat</a>
                             </li>
                             <li>
-                                <a href=#>Tilastot</a>
+                                <a href="#">Tilastot</a>
                             </li>
                             <li>
-                                <a href=#>Yhteystiedot</a>
+                                <a href="#">Yhteystiedot</a>
                             </li>
                         </ul>
                     </nav>
@@ -61,7 +61,7 @@
                         <fieldset>
                             <legend>Aktiivinen näissä asioissa</legend>
                             <div class="tag-cloud  tagcloud--select">
-                                <ul class="tagcloud__content">
+                                <ul class="items">
                                     <li class="l">
                                         <a href="../../aiheet/aihe/" class="disabled">Verotus</a>
                                     </li>

--- a/templates/party/list.html
+++ b/templates/party/list.html
@@ -61,7 +61,7 @@
         </div>
         -->
         <script id="party-list-item-template" type="text/template">
-        <li class="grid-listing-box col-md-5">
+        <li class="col-md-5">
             {% comment %}party_governing_status == opposition / government{% endcomment %}
             <div class="party-list-item <%= party_governing_status %>">
                 <div class="mplist-grid__content">
@@ -71,25 +71,25 @@
                         </h4>
                     </div>
                     <div class="row">
-                        <div class="col-md-5">
+                        <div class="col-sm-5">
                             <div class="portrait">
                                 <a href="<%= view_url %>">
-                                    <img src="<%= logo_128x128 %>">
+                                    <img src="/api/v1/party/<%= name %>/logo?dim=128x128">
                                 </a>
                             </div>
                         </div>
-                        <div class="col-md-10">
+                        <div class="col-sm-10">
                             <div class="stats">
                                 <div class="location"><%= name %></div>
-                                <span class="badge  badge--terms  js-tooltip" title="Kansanedustajia">
+                                <span class="badge  badge--terms  js-tooltip" title="{% trans "MPs" %}">
                                     <i class="typcn  typcn-user  typcn--medium"></i><%= member_count %></span>
-                                <span class="badge  badge--minister  js-tooltip" title="Ministereitä">
+                                <span class="badge  badge--minister  js-tooltip" title="{% trans "ministers" %}">
                                     <i class="typcn  typcn-briefcase  typcn--medium"></i><%= minister_count %></span>
                                 <hr>
                                 <div class="row">
                                     <div class="col-md-6">{% trans "Activity" %}</div>
                                     <div class="col-md-7">
-                                        <div class="progress js-tooltip" title="22 pistettä">
+                                        <div class="progress js-tooltip" title="x {% trans "points" %}">
                                             <div class="progress-bar" style="width:12px"></div>
                                         </div>
                                     </div>

--- a/templates/party/mps.html
+++ b/templates/party/mps.html
@@ -1,0 +1,113 @@
+{% extends "base.html" %}
+{% load compress static thumbnail i18n %}
+
+{% block title %}{{ party.full_name }}{% endblock %}
+
+{% block head %}
+<!-- Initial models -->
+    <script type="text/javascript">
+        party_json = {{party_json|safe}};
+        party_list_json = {{member_list_json|safe}};
+    </script>
+<!-- Backbone models -->
+{% compress js %}
+    <script type="text/coffeescript" src="{% static "js/models.coffee" %}"></script>
+{% endcompress %}
+{% endblock %}
+{% block main_class %}container member-list{% endblock %}
+{% block content %}
+<!-- Content ================================================== -->
+    <div class="row">
+        <div class="col-md-5">
+            <div class="row">
+                <div class="col-md-15">
+                    <div class="party-card">
+                        <div class="page-heading">
+                            <h1>{{ party.full_name}}</h1>
+                        </div>
+                        <img src="/api/v1/party/{{ party.name }}/logo?dim=128x128">
+                    </div>
+                </div>
+                <!-- PARTY NAVI BOX -->
+                <div class="col-md-15">
+                    <nav class="side-navigation">
+                        <ul class="nav nav-pills nav-stacked">
+                            <li class="active">
+                                <a href="#">Perustiedot</a>
+                            </li>
+                            <li>
+                                <a href="#">Valiokuntapaikat</a>
+                            </li>
+                            <li>
+                                <a href="{% url 'parliament.views.list_party_mps' name=party.name %}">Kansanedustajat</a>
+                            </li>
+                            <li>
+                                <a href="#">Tilastot</a>
+                            </li>
+                            <li>
+                                <a href="#">Yhteystiedot</a>
+                            </li>
+                        </ul>
+                    </nav>
+                </div>
+                <!-- PARTY NAVI BOX -->
+            </div>
+        </div>
+
+        <div class="col-md-10">    
+            <div class="content  content--party">
+                <h3>{% trans "List of MPs for this party" %}</h3>
+                <ul class="member-list row">
+                </ul>
+            </div>
+        </div>
+    </div>
+
+<script id="member-list-item-template" type="text/template">
+<li class="col-lg-7">
+    <div class="member-list-item">
+        <div class="header">
+            <h4 class="name"><a href="<%= view_url %>"><%= name %></a></h4>
+            <div class="party">
+                <a href="#PLACEHOLDER" class="js-tooltip" title="<%= party %>">
+                    <img src="<%= party %>" height='32' />
+                </a>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-5 portrait">
+                <a class="portrait-link" href="<%= view_url %>">
+                    <img src="<%= photo %>" />
+                </a>
+            </div>
+            <div class="col-lg-10">
+                <div class="info">
+                    <div class="location"><%= district_name %> vaalipiiri</div>
+                    <span class="badge badge--terms js-tooltip" title="{% trans 'Number of terms' %}">
+                        <i class="typcn typcn-calender"> </i><%= terms.length %>
+                    </span>
+                    <% if (minister) { %>
+                    <span class="badge badge--minister" title="<%= minister %>">
+                        <i class="typcn typcn-briefcase"></i>
+                    </span>
+                    <% } %>
+                    <hr />
+                    <div class="row">
+                        <div class="stat-name col-lg-6">Aktiivisuus:</div>
+                        <div class="stat-value col-lg-2"><%= stats.recent_activity %></div>
+                        <div class="col-lg-7">
+                            <div class="progress">
+                                <div class="progress-bar progress-bar-info" style="width: <%= stats.activity_ranking*100 %>%"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</li>
+</script>
+{% compress js %}
+    <script type="text/coffeescript" src="{% static "js/party-details.coffee" %}"></script>
+{% endcompress %}
+{% endblock %}

--- a/urls.py
+++ b/urls.py
@@ -37,6 +37,7 @@ urlpatterns += patterns('parliament.views',
 
     url(r'^party/$', 'list_parties'),
     url(r'^party/(?P<name>[-\w]+)/$', 'show_party'),
+    url(r'^party/(?P<name>[-\w]+)/mps/$', 'list_party_mps'),
 
     url(r'^topic/$', 'list_topics'),
     url(r'^topic/(?P<topic>\d+)-(?P<slug>[-\w]+)/$', 'show_topic'),


### PR DESCRIPTION
Mostly for commenting, although it does work. The duplicated menu obviously needs de-duplicating. Would it be appropriate to use Backbone router for the whole page?
